### PR TITLE
Fix: XML parser & WebKit

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "main": "./dom-parser.js",
   "scripts" : { "test": "proof platform win32 && proof test */*/*.t.js || t/test" },
   "engines": {"node": ">=0.1"},
-  "dependencies": {},
+  "dependencies": { "string.prototype.matchall": "3.0.1" },
   "devDependencies": { "proof": "0.0.28" },
   "maintainers": [{"name": "jindw","email": "jindw@xidea.org","url": "http://www.xidea.org"}],
   "contributors": [

--- a/sax.js
+++ b/sax.js
@@ -1,3 +1,4 @@
+var matchAll = require('string.prototype.matchall');
 //[4]   	NameStartChar	   ::=   	":" | [A-Z] | "_" | [a-z] | [#xC0-#xD6] | [#xD8-#xF6] | [#xF8-#x2FF] | [#x370-#x37D] | [#x37F-#x1FFF] | [#x200C-#x200D] | [#x2070-#x218F] | [#x2C00-#x2FEF] | [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]
 //[4a]   	NameChar	   ::=   	NameStartChar | "-" | "." | [0-9] | #xB7 | [#x0300-#x036F] | [#x203F-#x2040]
 //[5]   	Name	   ::=   	NameStartChar (NameChar)*
@@ -66,7 +67,7 @@ function parse(source,defaultNSMapCopy,entityMap,domBuilder,errorHandler){
 		}
 	}
 	function position(p,m){
-		while(p>=lineEnd && (m = linePattern.exec(source))){
+		while(p>=lineEnd && (m = matches[locator.lineNumber])) {
 			lineStart = m.index;
 			lineEnd = lineStart + m[0].length;
 			locator.lineNumber++;
@@ -76,7 +77,7 @@ function parse(source,defaultNSMapCopy,entityMap,domBuilder,errorHandler){
 	}
 	var lineStart = 0;
 	var lineEnd = 0;
-	var linePattern = /.*(?:\r\n?|\n)|.*$/g
+	var matches = [...matchAll(source, /.*(?:\r\n?|\n)|.*$/g)];
 	var locator = domBuilder.locator;
 	
 	var parseStack = [{currentNSMap:defaultNSMapCopy}]


### PR DESCRIPTION
Replace usage of `Regex.prototype.exec` with shim of `Regex.prototype.matchAll`. This suppress the bug faced with certain versions of WebKit where the inner state of the regex would be lost and iteration would restart at the beginning of the string. Tested with Android 7.

https://app.asana.com/0/244065166232575/1129162278755512/f
